### PR TITLE
fix: use correct DB host resolution for k8s

### DIFF
--- a/sole-spot-k8s.yaml
+++ b/sole-spot-k8s.yaml
@@ -20,6 +20,8 @@ spec:
           ports:
             - containerPort: 8080
           env:
+            - name: K8
+              value: "YES"
             - name: DB_HOST
               value: "postgres-service"
             - name: DB_NAME


### PR DESCRIPTION
- added K8 env check to prioritize k8s DNS service name (postgres-service)
- fallback order: K8 > DOCKER > localhost
- ensures correct service discovery inside k8 pods